### PR TITLE
Fixed Step-5 Typo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -111,7 +111,7 @@ npm install  pdf-node --save
  
   ```
 
-- Step 5- After setting all parameters, just pass document and options to `pdf.create` method.
+- Step 5- After setting all parameters, just pass document and options to `pdf` method.
 
   ```javascript
   pdf(document, options)


### PR DESCRIPTION
Fixed Typo in line no-114, which said we are using 'pdf.create' method while we are using only the 'pdf' method here.